### PR TITLE
Change deprecated set-output to use proposed env. file instead

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -205,8 +205,8 @@ runs:
             throw "Sorry, installing Clang is unsupported on $os"
         }
 
-        echo "::set-output name=clang::$clang"
-        echo "::set-output name=clangxx::$clangxx"
+        echo "clang=$clang" >> $env:GITHUB_OUTPUT
+        echo "clangxx=$clangxx" >> $env:GITHUB_OUTPUT
       shell: pwsh
 
     - run: |


### PR DESCRIPTION
Removes annotations/warnings received in [builds](https://github.com/Nordix/flatcc/actions/runs/3469147024).

Fixes #7 