### PR TITLE
add clang 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        version: ['3.9', '4.0', 4, '5.0', 5, '6.0', 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        version: ['3.9', '4.0', 4, '5.0', 5, '6.0', 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         exclude:
           - {os: ubuntu-20.04, version: '3.9'}
           - {os: ubuntu-20.04, version: '4.0'}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ below.
 | 13        | ✓      | ✓     | ✓
 | 14        | ✓      | ✓     | ✓
 | 15        | ✓      | ✓     | ✓
+| 16        | ✓      | ✓     | ✓
 
 This table should be updated periodically; it's a work-in-progress.
 


### PR DESCRIPTION
clang 16 is out for a while now and supported in 18.04 - 22.04