### PR TITLE
feat: update ubuntu releases and clang versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,13 @@ jobs:
     strategy:
       matrix:
         platform: [x86, x64]
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2019, windows-2022]
+        exclude:
+            # 32-bit builds on ubuntu-24.04 fail due to a bug in Ubuntu linux-azure
+            # kernel that Github runner images use.
+            # See: https://bugs.launchpad.net/ubuntu/+source/linux-signed-azure/+bug/2071445
+            # TODO: Remove this exclusion when the bugfix is available on the runners.
+          - {platform: x86, os: ubuntu-24.04}
     runs-on: '${{ matrix.os }}'
     name: 'Test: ${{ matrix.os }} / ${{ matrix.platform }}'
     steps:
@@ -37,25 +43,24 @@ jobs:
   versions:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        version: ['3.9', '4.0', 4, '5.0', 5, '6.0', 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        version: ['6.0', 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
         exclude:
-          - {os: ubuntu-20.04, version: '3.9'}
-          - {os: ubuntu-20.04, version: '4.0'}
-          - {os: ubuntu-20.04, version: 4}
-          - {os: ubuntu-20.04, version: '5.0'}
-          - {os: ubuntu-20.04, version: 5}
-          - {os: ubuntu-22.04, version: '3.9'}
-          - {os: ubuntu-22.04, version: '4.0'}
-          - {os: ubuntu-22.04, version: 4}
-          - {os: ubuntu-22.04, version: '5.0'}
-          - {os: ubuntu-22.04, version: 5}
           - {os: ubuntu-22.04, version: '6.0'}
           - {os: ubuntu-22.04, version: 6}
           - {os: ubuntu-22.04, version: 7}
           - {os: ubuntu-22.04, version: 8}
           - {os: ubuntu-22.04, version: 9}
           - {os: ubuntu-22.04, version: 10}
+          - {os: ubuntu-24.04, version: '6.0'}
+          - {os: ubuntu-24.04, version: 6}
+          - {os: ubuntu-24.04, version: 7}
+          - {os: ubuntu-24.04, version: 8}
+          - {os: ubuntu-24.04, version: 9}
+          - {os: ubuntu-24.04, version: 10}
+          - {os: ubuntu-24.04, version: 11}
+          - {os: ubuntu-24.04, version: 12}
+          - {os: ubuntu-24.04, version: 13}
     runs-on: '${{ matrix.os }}'
     name: 'Version: ${{ matrix.os }} / ${{ matrix.version }}'
     steps:

--- a/README.md
+++ b/README.md
@@ -61,28 +61,34 @@ The `version` parameter value is not checked for being an available version for
 the current distribution.
 The supported versions for a particular distribution are those found in that
 distro's repositories & those in the LLVM repository.
-For example, you can find the list of available versions as of January 2023
+For example, you can find the list of available versions as of July 2024
 below.
 
-| `version` | Bionic | Focal | Jammy
-| --------- | ------ | ----- | -----
-| 3.9       | ✓      |       |
-| 4.0       | ✓      |       |
-| 5.0       | ✓      |       |
-| 6.0       | ✓      | ✓     |
-| 7         | ✓      | ✓     |
-| 8         | ✓      | ✓     |
-| 9         | ✓      | ✓     |
-| 10        | ✓      | ✓     |
-| 11        | ✓      | ✓     | ✓
-| 12        | ✓      | ✓     | ✓
-| 13        | ✓      | ✓     | ✓
-| 14        | ✓      | ✓     | ✓
-| 15        | ✓      | ✓     | ✓
+| `version` | Focal | Jammy | Noble
+| --------- | ----- | ----- | -----
+| 6.0       | ✓     |       |
+| 7         | ✓     |       |
+| 8         | ✓     |       |
+| 9         | ✓     |       |
+| 10        | ✓     |       |
+| 11        | ✓     | ✓     |
+| 12        | ✓     | ✓     |
+| 13        | ✓     | ✓     |
+| 14        | ✓     | ✓     | ✓
+| 15        | ✓     | ✓     | ✓
+| 16        | ✓     | ✓     | ✓
+| 17        | ✓     | ✓     | ✓
+| 18        | ✓     | ✓     | ✓
 
 This table should be updated periodically; it's a work-in-progress.
 
 On Windows and Cygwin, the `version` parameter is ignored.
+
+:warning: The 32-bit build on Noble Numbat (Ubuntu 24.04 LTS) is temporarily not supported
+due to a bug in the linux-azure kernel used by Github runner images. See this
+[bug report](https://bugs.launchpad.net/ubuntu/+source/linux-signed-azure/+bug/2071445)
+for more information. Related [issue](https://bugs.launchpad.net/ubuntu/+source/linux-signed-azure/+bug/2071445)
+on actions/runner-images.
 
 License
 -------

--- a/action.yml
+++ b/action.yml
@@ -83,10 +83,8 @@ runs:
 
             switch -Exact ($Version) {
                 # Since version 7, they dropped the .0 suffix. The earliest
-                # version supported is 3.9 on Bionic; versions 4, 5 and 6 are
-                # mapped to LLVM-friendly 4.0, 5.0 and 6.0.
-                '4' { '4.0' }
-                '5' { '5.0' }
+                # version supported is 3.9 on Bionic; version 6 is
+                # mapped to LLVM-friendly 6.0.
                 '6' { '6.0' }
                 default { $Version }
             }


### PR DESCRIPTION
- add Ubuntu release 24.04 LTS (Noble Numbat).
- remove Ubuntu release 18.04 LTS (Bionic Beaver) as Github runners no longer support it.
- remove clang versions 3.9, 4.0, 5.0, 6.0 which are now obsolete due to removal of Bionic.
- add clang versions 16, 17, 18.